### PR TITLE
Ignore XDG env vars set to relative paths

### DIFF
--- a/xdgbasedir.go
+++ b/xdgbasedir.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -106,18 +107,24 @@ func splitAndReturnUnique(str string, sep string) []string {
 func getInEnvOrJoinWithHome(envName string, directory string) (string, error) {
 	configHome := osGetEnv(envName)
 	if configHome != "" {
-		return configHome, nil
+		// XDG Base Directory Specification states:
+		// "All paths set in these environment variables must be absolute. If an
+		// implementation encounters a relative path in any of these variables
+		// it should consider the path invalid and ignore it."
+		if filepath.IsAbs(configHome) {
+			return configHome, nil
+		}
 	}
 	return joinWithHome(directory)
 }
 
 func joinWithHome(dir string) (string, error) {
-        homeDir := os.Getenv("HOME")
+	homeDir := os.Getenv("HOME")
 
 	if homeDir == "" {
 		usr, err := userCurrent()
 		if err != nil {
-		   return "", err
+			return "", err
 		}
 		homeDir = usr.HomeDir
 	}

--- a/xdgbasedir_test.go
+++ b/xdgbasedir_test.go
@@ -20,7 +20,24 @@ func expectEquals(t *testing.T, expected string, given string, msg string) {
 	}
 }
 
+// clearEnvVars explicitly unsets all XDG environment variables, to ensure that
+// user environment does not affect tests
+func clearEnvVars() {
+	// explicitly unset, in case set in environment
+	os.Setenv("HOME", "")
+	os.Setenv("XDG_DATA_HOME", "")
+	os.Setenv("XDG_CONFIG_HOME", "")
+	os.Setenv("XDG_CACHE_HOME", "")
+	os.Setenv("XDG_CONFIG_DIRS", "")
+	os.Setenv("XDG_DATA_DIRS", "")
+	os.Setenv("XDG_RUNTIME_DIR", "")
+}
+
+// TestGetAll checks path resolution when no XDG_* env vars nor HOME are set
 func TestGetAll(t *testing.T) {
+	clearEnvVars()
+
+	// mock current user home directory location
 	userCurrent = func() (*user.User, error) {
 		return &user.User{HomeDir: "/home/Person"}, nil
 	}
@@ -45,7 +62,11 @@ func TestGetAll(t *testing.T) {
 	expectEquals(t, "/home/Person/.cache", cacheHome, "Unexpected cache")
 }
 
+// TestDirectories
 func TestDirectories(t *testing.T) {
+	clearEnvVars()
+
+	// mock current user home directory location
 	userCurrent = func() (*user.User, error) {
 		return &user.User{HomeDir: "/home/Person"}, nil
 	}


### PR DESCRIPTION
Previously there was no check that an `XDG_*` env variable referred to an absolute path. The spec states:

> All paths set in these environment variables must be absolute. If an implementation encounters a relative path in any of these variables it should consider the path invalid and ignore it.

This patch adds a check that the path is absolute, otherwise it ignores it. It also explicitly unsets `XDG_*` env variables and the `HOME` env var in tests, to guarantee that a user's environment does not inadvertently affect the test results.